### PR TITLE
Fix room list refresh after creation

### DIFF
--- a/src/hooks/useFocusRoom.js
+++ b/src/hooks/useFocusRoom.js
@@ -287,6 +287,9 @@ const useFocusRoom = () => {
         await joinRoom(room.id, { displayName: roomData.creatorName || 'You' });
       }
 
+      // Refresh the room list to include the newly created room
+      fetchRooms().catch(err => console.error('Failed to refresh rooms after creation:', err));
+
       setError(null);
       return room;
     } catch (err) {


### PR DESCRIPTION
- Add fetchRooms() call after successful room creation
- Newly created rooms now appear immediately in the room list
- Non-blocking refresh with error handling