### PR TITLE
Fix scheduled room creation modal behavior

### DIFF
--- a/src/hooks/useFocusRoom.js
+++ b/src/hooks/useFocusRoom.js
@@ -282,8 +282,10 @@ const useFocusRoom = () => {
 
       const room = await service.createFocusRoom(roomData);
 
-      // Auto-join the created room (even if scheduled, so creator is "ready")
-      await joinRoom(room.id, { displayName: roomData.creatorName || 'You' });
+      // Auto-join the created room only if it's not scheduled
+      if (room.status !== 'scheduled') {
+        await joinRoom(room.id, { displayName: roomData.creatorName || 'You' });
+      }
 
       // Refresh the room list to include the newly created room
       fetchRooms().catch(err => console.error('Failed to refresh rooms after creation:', err));


### PR DESCRIPTION
- Prevent auto-join for scheduled rooms in createRoom function
- Modal now closes properly after creating scheduled rooms
- Eliminates duplicate error notifications (toast + alert)
- Maintains proper error handling for actual creation failures